### PR TITLE
Punctuation typo fixed

### DIFF
--- a/05-lection-predicate.tex
+++ b/05-lection-predicate.tex
@@ -92,21 +92,21 @@ $$\color{blue}\forall {\color{red}x}.{\color{red}\sin x} = {\color{red}0} \vee {
 \item Два типа: предметные и логические выражения. \pause
 \item Предметные выражения: метапеременная {\color{blue}$\theta$}. \pause
 \begin{itemize}
-\item Предметные переменные: {\color{blue}$a$}, {\color{blue}$b$}, {\color{blue}$c$}, ..., метапеременные {\color{blue}$x$}, {\color{blue}$y$}. \pause
+\item Предметные переменные: {\color{blue}$a$}, {\color{blue}$b$}, {\color{blue}$c$}, \dots, метапеременные {\color{blue}$x$}, {\color{blue}$y$}. \pause
 \item Функциональные выражения: {\color{blue}$f(\theta_1,\dots,\theta_n)$}, метапеременные {\color{blue}$f$}, {\color{blue}$g$}, ....\\\pause
 %Имена разнообразны: {\color{blue}$(\theta_1+\theta_2)$}, {\color{blue}$0$} и т.п.\pause
 \item Примеры: %{\color{blue}$(x+1)^2$}. \\\pause
 % Раскроем сокращения: {\color{blue}$(\theta_0+\theta_1)\equiv p(\theta_0,\theta_1)$},
 %   {\color{blue}$\theta_1^2\equiv q(\theta_1)$}, {\color{blue}$1\equiv r$}, {\color{blue}$2\equiv s$}. \pause\\
   {\color{blue}$r$},
-  {\color{blue}$q(p(x,s),r)$}
+  {\color{blue}$q(p(x,s),r)$}.
 \end{itemize}\pause
 \item Логические выражения: метапеременные {\color{blue}$\alpha$}, {\color{blue}$\beta$}, {\color{blue}$\gamma$}, ...
 \begin{itemize}
 \item Предикатные выражения: {\color{blue}$P(\theta_1,\dots,\theta_n)$}, метапеременная {\color{blue}$P$}.\\\pause
-Имена: {\color{blue}$A$}, {\color{blue}$B$}, {\color{blue}$C$}, ..., \pause %также {\color{blue}$(\theta_1=\theta_2)$} и т.п.\pause
+Имена: {\color{blue}$A$}, {\color{blue}$B$}, {\color{blue}$C$}, \dots, \pause %также {\color{blue}$(\theta_1=\theta_2)$} и т.п.\pause
 \item Связки: {\color{blue}$(\varphi\vee\psi)$}, {\color{blue}$(\varphi\with\psi)$}, {\color{blue}$(\varphi\rightarrow\psi)$}, 
-   {\color{blue}$(\neg\varphi)$}\pause
+   {\color{blue}$(\neg\varphi)$}.\pause
 \item Кванторы: {\color{blue}$(\forall x.\varphi)$} и {\color{blue}$(\exists x.\varphi)$}.
 \end{itemize}
 %\item Пример: $\forall \epsilon.\exists \delta.|x-x_0|<\delta\rightarrow|f(x)-f(x_0)|<\epsilon$\pause

--- a/06-lection-completeness.tex
+++ b/06-lection-completeness.tex
@@ -378,7 +378,7 @@ $W$
 \begin{proof}
 Покажем, что при $\varphi\in M^*$ выполнено $\mathcal{M}\models\varphi$. Докажем индукцией по количеству кванторов в $\varphi$.\pause
 \begin{itemize}
-\item База: $\varphi$ без кванторов. Тогда $\varphi\in M^\text{Б}$, отсюда $\mathcal{M}\models\varphi$ по построению $\mathcal{M}$\pause
+\item База: $\varphi$ без кванторов. Тогда $\varphi\in M^\text{Б}$, отсюда $\mathcal{M}\models\varphi$ по построению $\mathcal{M}$.\pause
 \item Переход: пусть утверждение выполнено для всех формул с $n$ кванторами. Покажем, что это выполнено и для $n+1$ кванторов.\pause
 \begin{itemize}
 \item Рассмотрим $\varphi = \exists x.\psi$, случай квантор всеобщности --- аналогично.\pause
@@ -386,7 +386,7 @@ $W$
 \item Раз $\exists x.\psi \in M^*$, то существует $k$, что $\exists x.\psi \in M_k$.\pause
 \item Значит, $\psi[x := d^{k+1}_i] \in M_{k+1}$. \pause
 \item По индукционному предположению, $\mathcal{M}\models\psi[x := d^{k+1}_i]$ --- в формуле $n$ кванторов.\pause
-\item Но тогда $\llbracket \psi \rrbracket^{x := \llbracket d^{k+1}_i\rrbracket} = \text{И}$\pause
+\item Но тогда $\llbracket \psi \rrbracket^{x := \llbracket d^{k+1}_i\rrbracket} = \text{И}$.\pause
 \item Отсюда $\mathcal{M}\models\exists x.\psi$.
 \end{itemize}
 \end{itemize}
@@ -653,7 +653,7 @@ $W$
 \begin{proof}
 Покажем, что при $\varphi\in M^*$ выполнено $\mathcal{M}\models\varphi$. Докажем индукцией по количеству кванторов в $\varphi$.\pause
 \begin{itemize}
-\item База: $\varphi$ без кванторов. Тогда $\varphi\in M^\text{Б}$, отсюда $\mathcal{M}\models\varphi$ по построению $\mathcal{M}$\pause
+\item База: $\varphi$ без кванторов. Тогда $\varphi\in M^\text{Б}$, отсюда $\mathcal{M}\models\varphi$ по построению $\mathcal{M}$.\pause
 \item Переход: пусть утверждение выполнено для всех формул с $n$ кванторами. Покажем, что это выполнено и для $n+1$ кванторов.\pause
 \begin{itemize}
 \item Рассмотрим $\varphi = \exists x.\psi$, случай квантор всеобщности --- аналогично.\pause
@@ -661,7 +661,7 @@ $W$
 \item Раз $\exists x.\psi \in M^*$, то существует $k$, что $\exists x.\psi \in M_k$.\pause
 \item Значит, $\psi[x := d^{k+1}_i] \in M_{k+1}$. \pause
 \item По индукционному предположению, $\mathcal{M}\models\psi[x := d^{k+1}_i]$ --- в формуле $n$ кванторов.\pause
-\item Но тогда $\llbracket \psi \rrbracket^{x := \llbracket d^{k+1}_i\rrbracket} = \text{И}$\pause
+\item Но тогда $\llbracket \psi \rrbracket^{x := \llbracket d^{k+1}_i\rrbracket} = \text{И}$.\pause
 \item Отсюда $\mathcal{M}\models\exists x.\psi$.
 \end{itemize}
 \end{itemize}

--- a/07-lection-undecidability.tex
+++ b/07-lection-undecidability.tex
@@ -53,7 +53,7 @@
 
 \begin{frame}{Машина, меняющая все 0 на 1, а все 1 --- на 0}
 \begin{enumerate}
-\item Внешний алфавит $\varepsilon, 0, 1$
+\item Внешний алфавит $\varepsilon, 0, 1$.
 \item Внутренний алфавит $s_s, s_f$ (начальное и завершающее состояния соответственно).
 \item Переходы:
 
@@ -94,7 +94,7 @@ $\underline{0}11$ \pause $\Rightarrow 1\underline{1}1$ \pause $\Rightarrow 10\un
 \begin{frame}{Кодируем состояние}
 \begin{enumerate}
 \item внешний алфавит: $n$ 0-местных функциональных символов $q_1, \dots, q_n$; $q_\varepsilon$ --- символ-заполнитель.
-\item список: $\varepsilon$ и $c(l,s)$; <<abc>> представим как $c(q_a,c(q_b,c(q_c,\varepsilon)))$;
+\item список: $\varepsilon$ и $c(l,s)$; <<abc>> представим как $c(q_a,c(q_b,c(q_c,\varepsilon)))$.
 \item положение головки: <<ab.pq>> как $(c(q_b,c(q_a,\varepsilon)), c(q_p,c(q_q,\varepsilon)))$.
 \item внутренний алфавит: $k$ 0-местных функциональных символов $s_1, \dots, s_k$. Из них выделенные $s_s$ --- начальное и
 $s_f$ --- завершающее состояние.

--- a/09-goedel.tex
+++ b/09-goedel.tex
@@ -204,22 +204,22 @@ $\gamma$, что $\vdash \gamma \leftrightarrow \neg\pi(\overline{\ulcorner\gamm
 
 \begin{enumerate}
 \item По условию 2, $\vdash \pi(\overline{\ulcorner\gamma\urcorner}) \rightarrow \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\urcorner})$.
-По теореме о дедукции $\pi(\overline{\ulcorner\gamma\urcorner})\vdash \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\urcorner})$.
+По теореме о дедукции $\pi(\overline{\ulcorner\gamma\urcorner})\vdash \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\urcorner})$;
 
 \item Так как $\vdash \pi(\overline{\ulcorner\gamma\urcorner})\rightarrow\neg\gamma$, то 
-по условию 1 $\vdash \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\rightarrow\neg\gamma\urcorner})$
+по условию 1 $\vdash \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\rightarrow\neg\gamma\urcorner})$;
 
 \item По условию 3, $\pi(\overline{\ulcorner\gamma\urcorner})\vdash \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\urcorner})
 \rightarrow \pi(\overline{\ulcorner\pi(\overline{\ulcorner\gamma\urcorner})\rightarrow\neg\gamma\urcorner})\rightarrow
-\pi(\overline{\ulcorner\neg\gamma\urcorner})$
+\pi(\overline{\ulcorner\neg\gamma\urcorner})$;
 
-\item Таким образом, $\pi(\overline{\ulcorner\gamma\urcorner})\vdash\pi(\overline{\ulcorner\neg\gamma\urcorner})$.
+\item Таким образом, $\pi(\overline{\ulcorner\gamma\urcorner})\vdash\pi(\overline{\ulcorner\neg\gamma\urcorner})$;
 
-\item Однако, $\vdash \gamma\rightarrow\neg\gamma\rightarrow 1=0$. Условие 3 (применить два раза) даст $\pi(\overline{\ulcorner\gamma\urcorner})\vdash \pi(\overline{\ulcorner 1=0 \urcorner})$
+\item Однако, $\vdash \gamma\rightarrow\neg\gamma\rightarrow 1=0$. Условие 3 (применить два раза) даст $\pi(\overline{\ulcorner\gamma\urcorner})\vdash \pi(\overline{\ulcorner 1=0 \urcorner})$.
 \end{enumerate}
 
-\item $\neg\pi(\overline{\ulcorner 1=0 \urcorner})\rightarrow\neg\pi(\overline{\ulcorner\gamma\urcorner})$ (т. о дедукции, контрапозиция)
-\item $\vdash \neg\pi(\overline{\ulcorner 1=0 \urcorner})\rightarrow\gamma$ (определение $\gamma$)
+\item $\neg\pi(\overline{\ulcorner 1=0 \urcorner})\rightarrow\neg\pi(\overline{\ulcorner\gamma\urcorner})$ (т. о дедукции, контрапозиция).
+\item $\vdash \neg\pi(\overline{\ulcorner 1=0 \urcorner})\rightarrow\gamma$ (определение $\gamma$).
 \end{enumerate}
 \end{frame}
 


### PR DESCRIPTION
На лекции 5 (первый коммит):
Базовые исправления ошибок пунктуации на перечислениях.
Бонусом заменены `...` на `\dots` для консистенции.

На лекции 6 (второй коммит):
Добавлены точки в конце для консистенции.

На лекции 7 (третий коммит):
Добавлена точка.
Изменена `;` на `.` для консистенции.

На лекции 9 (четвёртый коммит):
Переработана пунктуация на перечислениях.

А также файлы не 8, 9, 13 не соответствуют шаблону остальных файлов. Regex: `[0-9]{2}-lection-.*.tex`.

Ходжаяров Адис M3235.