### PR TITLE
add remark in definition of transfinite induction

### DIFF
--- a/13-correctness.tex
+++ b/13-correctness.tex
@@ -60,7 +60,7 @@ $(\Leftarrow)$ возьмём $\psi(x) := \forall t.t\le x\rightarrow\varphi(t)$
 теории множеств --- выполнено:
 \begin{enumerate}
 \item $\varphi(\varnothing)$
-\item Если $\forall u.u \in \upsilon \rightarrow \varphi(u)$, то $\varphi(\upsilon)$
+\item Если $\forall u.u \in \upsilon \rightarrow \varphi(u)$, то $\varphi(\upsilon)$ (где $\upsilon$ - это ординал)
 \end{enumerate}
 то $\forall u.\varphi(u)$
 \end{thm}


### PR DESCRIPTION
На лекции акцентировалось внимание на том, что \upsilon - это ординал.
Бондарев Никита M3234