### PR TITLE
Typos in Lection 13, 14

### DIFF
--- a/13-correctness.tex
+++ b/13-correctness.tex
@@ -181,7 +181,7 @@ $$\infer{(\forall a.a = a)_\omega}{
 \end{proof}
 \end{frame}
 
-\begin{frame}{Случай 1. Не сечение}
+\begin{frame}{Случай 2.1. Не сечение}
 $$\infer{\alpha}{\pi_{t_0}\quad\pi_{t_1}\quad\pi_{t_2}\quad\dots}$$
 Заменим доказательства посылок $\pi_i$ по индукционному предположению.
 
@@ -191,7 +191,7 @@ $$\infer{\alpha}{\pi_{t_0}\quad\pi_{t_1}\quad\pi_{t_2}\quad\dots}$$
 \end{enumerate}
 \end{frame}
 
-\begin{frame}{Случай 2.4. Сечение с формулой вида $\forall x.\alpha$}
+\begin{frame}{Случай 2.5. Сечение с формулой вида $\forall x.\alpha$}
 $$\infer{\zeta\vee\delta}{\zeta\vee\forall x.\alpha\quad\quad\neg(\forall x.\alpha)\vee\delta}$$
 Причём степень и порядок выводов компонент, соответственно, $(m_1,t_1)$ и $(m_2,t_2)$.
 \begin{enumerate}

--- a/14-curry-howard.tex
+++ b/14-curry-howard.tex
@@ -64,7 +64,7 @@ $(\lambda x.x\ x)\ (\lambda x.x\ x) \rightarrow_\beta (\lambda x.x\ x)\ (\lambda
 \end{frame}
 
 \begin{frame}{Чёрчевские нумералы}
-$$f^{(n)}(x) = \left\{\begin{array}{ll}x, & n = 0\\f(f^{(n-1}(x)), & n > 0\end{array}\right.$$
+$$f^{(n)}(x) = \left\{\begin{array}{ll}x, & n = 0\\f(f^{(n-1)}(x)), & n > 0\end{array}\right.$$
 
 \begin{dfn}
 Чёрчевский нумерал $\overline{n} = f^{(n)}(x)$


### PR DESCRIPTION
Лекция 13 - исправлена нумерация заголовка 2.4 -> 2.5 в соответствии с нумерацией в плане доказательства.
Лекция 14 - добавлена недостающая закрывающая скобка в степени. 
Смирнов Глеб М3239