### PR TITLE
Update 09-goedel.tex

### DIFF
--- a/09-goedel.tex
+++ b/09-goedel.tex
@@ -157,7 +157,7 @@ $\neg \pi(\overline{\ulcorner 1=0 \urcorner})$
 То есть, $\forall p.\neg\omega_1(\overline{\ulcorner\sigma\urcorner},p)$. \pause То есть, 
 если $\text{Consis}$, то $\sigma(\overline{\ulcorner\sigma\urcorner})$. \pause
 То есть, если $\text{Consis}$, то $\sigma(\overline{\ulcorner\sigma\urcorner})$, --- и это можно доказать,
-то есть $\vdash\text{Consis}\rightarrow\sigma(\overline{\ulcorner\sigma\urcorner})$. \pause Однако,
+то есть $\vdash\text{Consis}\rightarrow\sigma(\overline{\ulcorner\sigma\urcorner})$. \pause Однако 
 если формальная арифметика непротиворечива, то $\not\vdash\sigma(\overline{\ulcorner\sigma\urcorner})$.
 \end{proof}
 \end{frame}


### PR DESCRIPTION
Однако в данном случае не выделяется запятой (так как в значении "но"). Правило: "Все зависит от того, чем является слово "однако" в предложении. Если это союз в значении "но", то, как правило, "однако" ("однако же") стоит в начале предложения и запятой не отделяется."